### PR TITLE
Merge with meta-rauc/dunfell upstream to fix bundle images.

### DIFF
--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -86,9 +86,9 @@ do_populate_sysroot[noexec] = "1"
 do_package[noexec] = "1"
 do_package_qa[noexec] = "1"
 do_packagedata[noexec] = "1"
-do_package_write_ipk[noexec] = "1"
-do_package_write_deb[noexec] = "1"
-do_package_write_rpm[noexec] = "1"
+deltask do_package_write_ipk
+deltask do_package_write_deb
+deltask do_package_write_rpm
 
 RAUC_BUNDLE_COMPATIBLE  ??= "${MACHINE}-${TARGET_VENDOR}"
 RAUC_BUNDLE_VERSION     ??= "${PV}"

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -52,6 +52,9 @@
 # Extra arguments may be passed to the bundle command with BUNDLE_ARGS eg:
 #   BUNDLE_ARGS += ' --mksquashfs-args="-comp zstd -Xcompression-level 22" '
 #
+# Likewise, extra arguments can be passed to the convert command with
+# CONVERTS_ARGS.
+#
 # Additionally you need to provide a certificate and a key file
 #
 #   RAUC_KEY_FILE ?= "development-1.key.pem"
@@ -60,6 +63,10 @@
 # For bundle signature verification a keyring file must be provided
 #
 #   RAUC_KEYRING_FILE ?= "ca.cert.pem"
+#
+# Enable building casync bundles with
+#
+#   RAUC_CASYNC_BUNDLE = "1"
 
 LICENSE = "MIT"
 
@@ -98,6 +105,8 @@ RAUC_BUNDLE_HOOKS[doc] = "Allows to specify an additional hook executable and bu
 
 RAUC_BUNDLE_EXTRA_FILES[doc] = "Specifies list of additional files to add to bundle. Files must either be located in WORKDIR (added by SRC_URI) or DEPLOY_DIR_IMAGE (assured by RAUC_BUNDLE_EXTRA_DEPENDS)"
 RAUC_BUNDLE_EXTRA_DEPENDS[doc] = "Specifies list of recipes that create artifacts in DEPLOY_DIR_IMAGE. For recipes not depending on do_deploy task also <recipename>:do_<taskname> notation is supported"
+
+RAUC_CASYNC_BUNDLE ??= "0"
 
 # Create dependency list from images
 python __anonymous() {
@@ -145,9 +154,12 @@ RAUC_KEYRING_FILE ??= ""
 RAUC_KEYRING_FILE[doc] = "Specifies the path to the RAUC keyring file used for bundle signature verification. Use COREBASE to reference files located in any shared BSP folder."
 BUNDLE_ARGS ??= ""
 BUNDLE_ARGS[doc] = "Specifies any extra arguments to pass to the rauc bundle command."
+CONVERT_ARGS ??= ""
+CONVERT_ARGS[doc] = "Specifies any extra arguments to pass to the rauc convert command."
 
 
 DEPENDS = "rauc-native squashfs-tools-native"
+DEPENDS += "${@bb.utils.contains('RAUC_CASYNC_BUNDLE', '1', 'virtual/fakeroot-native casync-native', '', d)}"
 
 def write_manifest(d):
     import shutil
@@ -309,6 +321,27 @@ do_bundle() {
 		${BUNDLE_ARGS} \
 		${BUNDLE_DIR} \
 		${B}/bundle.raucb
+
+	if [ ${RAUC_CASYNC_BUNDLE} -eq 1 ]; then
+		if [ -z "${RAUC_KEYRING_FILE}" ]; then
+			bbfatal "'RAUC_KEYRING_FILE' not set. Please set a valid keyring file location."
+		fi
+
+		# There is no package providing a binary named "fakeroot" but instead a
+		# replacement named "pseudo". But casync requires fakeroot to be
+		# installed, thus make a symlink.
+		if ! [ -x "$(command -v fakeroot)" ]; then
+			ln -sf ${STAGING_DIR_NATIVE}${bindir}/pseudo ${STAGING_DIR_NATIVE}${bindir}/fakeroot
+		fi
+		PSEUDO_PREFIX=${STAGING_DIR_NATIVE}/usr ${STAGING_DIR_NATIVE}${bindir}/rauc convert \
+			--debug \
+			--cert=${RAUC_CERT_FILE} \
+			--key=${RAUC_KEY_FILE} \
+			--keyring=${RAUC_KEYRING_FILE} \
+			${CONVERT_ARGS} \
+			${B}/bundle.raucb \
+			${B}/casync-bundle.raucb
+	fi
 }
 do_bundle[dirs] = "${B}"
 do_bundle[cleandirs] = "${B}"
@@ -321,6 +354,13 @@ do_deploy() {
 	install -d ${DEPLOYDIR}
 	install -m 0644 ${B}/bundle.raucb ${DEPLOYDIR}/${BUNDLE_NAME}${BUNDLE_EXTENSION}
 	ln -sf ${BUNDLE_NAME}${BUNDLE_EXTENSION} ${DEPLOYDIR}/${BUNDLE_LINK_NAME}${BUNDLE_EXTENSION}
+
+	if [ ${RAUC_CASYNC_BUNDLE} -eq 1 ]; then
+		install ${B}/casync-bundle${BUNDLE_EXTENSION} ${DEPLOYDIR}/casync-${BUNDLE_NAME}${BUNDLE_EXTENSION}
+		cp -r ${B}/casync-bundle.castr ${DEPLOYDIR}/casync-${BUNDLE_NAME}.castr
+		ln -sf casync-${BUNDLE_NAME}${BUNDLE_EXTENSION} ${DEPLOYDIR}/casync-${BUNDLE_LINK_NAME}${BUNDLE_EXTENSION}
+		ln -sf casync-${BUNDLE_NAME}.castr ${DEPLOYDIR}/casync-${BUNDLE_LINK_NAME}.castr
+	fi
 }
 
 addtask deploy after do_bundle before do_build

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -69,7 +69,6 @@ RAUC_IMAGE_FSTYPE[doc] = "Specifies the default file name extension to expect fo
 
 do_fetch[cleandirs] = "${S}"
 do_patch[noexec] = "1"
-do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[noexec] = "1"
 do_populate_sysroot[noexec] = "1"
@@ -240,7 +239,7 @@ def write_manifest(d):
 
     manifest.close()
 
-do_unpack_append() {
+python do_configure() {
     import shutil
     import os
     import stat

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -303,9 +303,6 @@ do_bundle() {
 		sign_options="--cert=${RAUC_CERT_FILE} --key=${RAUC_KEY_FILE}"
 	fi
 
-	if [ -e ${B}/bundle.raucb ]; then
-		rm ${B}/bundle.raucb
-	fi
 	${STAGING_DIR_NATIVE}${bindir}/rauc bundle \
 		--debug \
 		${sign_options} \
@@ -314,6 +311,7 @@ do_bundle() {
 		${B}/bundle.raucb
 }
 do_bundle[dirs] = "${B}"
+do_bundle[cleandirs] = "${B}"
 
 addtask bundle after do_configure before do_build
 

--- a/classes/bundle.bbclass
+++ b/classes/bundle.bbclass
@@ -56,6 +56,10 @@
 #
 #   RAUC_KEY_FILE ?= "development-1.key.pem"
 #   RAUC_CERT_FILE ?= "development-1.cert.pem"
+#
+# For bundle signature verification a keyring file must be provided
+#
+#   RAUC_KEYRING_FILE ?= "ca.cert.pem"
 
 LICENSE = "MIT"
 
@@ -137,6 +141,8 @@ RAUC_KEY_FILE ??= ""
 RAUC_KEY_FILE[doc] = "Specifies the path to the RAUC key file used for signing. Use COREBASE to reference files located in any shared BSP folder."
 RAUC_CERT_FILE ??= ""
 RAUC_CERT_FILE[doc] = "Specifies the path to the RAUC cert file used for signing. Use COREBASE to reference files located in any shared BSP folder."
+RAUC_KEYRING_FILE ??= ""
+RAUC_KEYRING_FILE[doc] = "Specifies the path to the RAUC keyring file used for bundle signature verification. Use COREBASE to reference files located in any shared BSP folder."
 BUNDLE_ARGS ??= ""
 BUNDLE_ARGS[doc] = "Specifies any extra arguments to pass to the rauc bundle command."
 

--- a/recipes-core/rauc/nativesdk-rauc_1.3.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.3.bb
@@ -1,3 +1,0 @@
-require rauc-1.3.inc
-
-inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.4.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.4.bb
@@ -1,0 +1,3 @@
+require rauc-1.4.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.4.inc
+++ b/recipes-core/rauc/rauc-1.4.inc
@@ -2,7 +2,7 @@ require rauc.inc
 
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[md5sum] = "04ba029daa51e1f70fe53d62f2c5ebc3"
-SRC_URI[sha256sum] = "4f6144447254753fcd19f2c5c70e79fa91d27253185b8928436f01528aa65e6c"
+SRC_URI[md5sum] = "c66e8bfb82d9d3838a270abaafeea044"
+SRC_URI[sha256sum] = "85aabf214cd93a37f7ad0b3aaad89eb94facf0f3ebf6e2edca945acbca9b0967"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,0 +1,11 @@
+inherit native deploy
+
+do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+
+do_deploy() {
+    install -d ${DEPLOY_DIR_TOOLS}
+    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
+    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
+}
+
+addtask deploy before do_package after do_install

--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,6 +1,7 @@
 inherit native deploy
 
 DEPENDS = "openssl-native glib-2.0-native"
+RRECOMMENDS_${PN} = "squashfs-tools-native"
 
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 

--- a/recipes-core/rauc/rauc-native.inc
+++ b/recipes-core/rauc/rauc-native.inc
@@ -1,5 +1,7 @@
 inherit native deploy
 
+DEPENDS = "openssl-native glib-2.0-native"
+
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
 
 do_deploy() {

--- a/recipes-core/rauc/rauc-native_1.3.bb
+++ b/recipes-core/rauc/rauc-native_1.3.bb
@@ -1,13 +1,2 @@
 require rauc-1.3.inc
-
-inherit native deploy
-
-do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
-
-do_deploy() {
-    install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
-}
-
-addtask deploy before do_package after do_install
+require rauc-native.inc

--- a/recipes-core/rauc/rauc-native_1.4.bb
+++ b/recipes-core/rauc/rauc-native_1.4.bb
@@ -1,2 +1,2 @@
-require rauc-1.3.inc
+require rauc-1.4.inc
 require rauc-native.inc

--- a/recipes-core/rauc/rauc-native_git.bb
+++ b/recipes-core/rauc/rauc-native_git.bb
@@ -1,13 +1,2 @@
 require rauc-git.inc
-
-inherit native deploy
-
-do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
-
-do_deploy() {
-    install -d ${DEPLOY_DIR_TOOLS}
-    install -m 0755 ${B}/rauc ${DEPLOY_DIR_TOOLS}/rauc-${PV}
-    ln -sf rauc-${PV} ${DEPLOY_DIR_TOOLS}/rauc
-}
-
-addtask deploy before do_package after do_install
+require rauc-native.inc

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -1,6 +1,8 @@
 RAUC_KEYRING_FILE ??= "ca.cert.pem"
 RAUC_KEYRING_URI ??= "file://${RAUC_KEYRING_FILE}"
 
+RRECOMMENDS_${PN} = "squashfs-tools"
+
 SRC_URI_append = " \
   file://system.conf \
   ${RAUC_KEYRING_URI} \

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -12,8 +12,6 @@ EXTRA_OECONF += "\
         --with-dbussystemservicedir=${datadir}/dbus-1/system-services \
         "
 
-RRECOMMENDS_${PN} = "squashfs-tools"
-
 PACKAGECONFIG[nocreate]  = "--disable-create,--enable-create,"
 PACKAGECONFIG[service] = "--enable-service,--enable-service=no,dbus,${PN}-service"
 PACKAGECONFIG[network] = "--enable-network,--enable-network=no,curl"

--- a/recipes-core/rauc/rauc_1.4.bb
+++ b/recipes-core/rauc/rauc_1.4.bb
@@ -1,2 +1,2 @@
-require rauc-1.3.inc
+require rauc-1.4.inc
 require rauc-target.inc

--- a/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
+++ b/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_git.bb
@@ -9,7 +9,7 @@ SRCREV = "d909982e9e4b84cb76b98bf85f25a0a88472301a"
 S = "${WORKDIR}/git"
 PV = "0.0+git${SRCPV}"
 
-inherit cmake pkgconfig systemd
+inherit cmake pkgconfig systemd useradd
 
 SYSTEMD_SERVICE_${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'rauc-hawkbit-updater.service', '', d)}"
 
@@ -17,6 +17,9 @@ PACKAGECONFIG ??= " \
     ${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)} \
 "
 PACKAGECONFIG[systemd] = "-DWITH_SYSTEMD=ON,,systemd"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "--system --home-dir / --no-create-home --shell /bin/false rauc-hawkbit"
 
 DEPENDS = "curl glib-2.0-native json-glib"
 


### PR DESCRIPTION
Meta-rauc upstream has recently cut a dunfell stable branch, and it includes some fixes which are desirable for our image builds. Specifically, [this bundle.bbclass change](https://github.com/rauc/meta-rauc/commit/5e94613dffa6b3301e5ca831aa054f4ed28c581f#diff-01f677aff3b09599b14ea5daa3d1472e) fixes an error with the oe-core/dunfell branch which otherwise prohibits packing bundle images into other image recipes - as in the case of building a recovery media ISO using the bundle image.

This patchset cherry-picks all the upstream commits into our base. An ff-merge is not possible, because our internal branch carries one out-of-stream commit. 

@ni/rtos 