### PR TITLE
meta-rauc: Currency merge with upstream hardknott branch

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.5.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.5.1.bb
@@ -1,3 +1,0 @@
-require rauc-1.5.1.inc
-
-inherit nativesdk

--- a/recipes-core/rauc/nativesdk-rauc_1.6.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.6.bb
@@ -1,0 +1,3 @@
+require rauc-1.6.inc
+
+inherit nativesdk

--- a/recipes-core/rauc/rauc-1.6.inc
+++ b/recipes-core/rauc/rauc-1.6.inc
@@ -2,6 +2,6 @@ require rauc.inc
 
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[sha256sum] = "d4ea009ce702bcb083d942398ccfedec959c6bbb7adc0fd77ae9314ce11d9d91"
+SRC_URI[sha256sum] = "86013788dd02321b7c3f913ad3a1f8802afbc784ec076fa278524a9e1ef9e7b0"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-native_1.6.bb
+++ b/recipes-core/rauc/rauc-native_1.6.bb
@@ -1,2 +1,2 @@
-require rauc-1.5.1.inc
+require rauc-1.6.inc
 require rauc-native.inc

--- a/recipes-core/rauc/rauc_1.6.bb
+++ b/recipes-core/rauc/rauc_1.6.bb
@@ -1,2 +1,2 @@
-require rauc-1.5.1.inc
+require rauc-1.6.inc
 require rauc-target.inc


### PR DESCRIPTION
This is the 2022Q2.1 currency merge with upstream hardknott branch.
There were no merge conflicts and no additional NI-specific patches are required.

**Testing**

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake nilrt-safemode-rootfs
- [x] bitbake nilrt-runmode-rootfs
- [x] bitbake nilrt-base-system-image
- [x] bitbake nilrt-recovery-media

Upstream ref: hardknott
AzDO [1848521](https://dev.azure.com/ni/DevCentral/_workitems/edit/1848521)

**Procedural note**
Maintainers please wait to pull this until PRs to other hardknott layers are ready.
Currently tracking one upstream issue in meta-openembedded, PR [569](https://github.com/openembedded/meta-openembedded/pull/569)

@ni/rtos 