### PR TITLE
meta-rauc: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-core/rauc/nativesdk-rauc_1.10.1.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.10.1.bb
@@ -1,0 +1,3 @@
+require rauc.inc
+require rauc-1.10.1.inc
+require nativesdk-rauc.inc

--- a/recipes-core/rauc/nativesdk-rauc_1.10.bb
+++ b/recipes-core/rauc/nativesdk-rauc_1.10.bb
@@ -1,3 +1,0 @@
-require rauc.inc
-require rauc-1.10.inc
-require nativesdk-rauc.inc

--- a/recipes-core/rauc/rauc-1.10.1.inc
+++ b/recipes-core/rauc/rauc-1.10.1.inc
@@ -1,5 +1,5 @@
 SRC_URI = "https://github.com/rauc/rauc/releases/download/v${PV}/rauc-${PV}.tar.xz"
 
-SRC_URI[sha256sum] = "d3eec057e74d41565bbdfa10ff8bb2edb38e39af2b2126f8ad1d2174ae034d47"
+SRC_URI[sha256sum] = "aa99164c5f54fd29b5c8456221b51f92c900884af66de3e1b7f15a25b7db98a7"
 
 UPSTREAM_CHECK_URI = "https://github.com/${BPN}/${BPN}/releases"

--- a/recipes-core/rauc/rauc-git.inc
+++ b/recipes-core/rauc/rauc-git.inc
@@ -4,10 +4,10 @@ SRC_URI = " \
   git://github.com/rauc/rauc.git;protocol=https;branch=master \
   "
 
-PV = "1.10+git${SRCPV}"
+PV = "1.10.1+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-SRCREV = "bbcb1da04d750dbe9cd4d9b84f8ab8b5052481bf"
+SRCREV = "734bf8937ab154b5edf38bf82c18ca0d7ff1a631"
 
 RAUC_USE_DEVEL_VERSION[doc] = "Global switch to enable RAUC development (git) version."
 RAUC_USE_DEVEL_VERSION ??= "-1"

--- a/recipes-core/rauc/rauc-native_1.10.1.bb
+++ b/recipes-core/rauc/rauc-native_1.10.1.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-native.inc
-require rauc-1.10.inc
+require rauc-1.10.1.inc

--- a/recipes-core/rauc/rauc-target.inc
+++ b/recipes-core/rauc/rauc-target.inc
@@ -71,7 +71,7 @@ RRECOMMENDS:${PN}:append = " ${PN}-mark-good"
 FILES:${PN}-mark-good = "${systemd_unitdir}/system/rauc-mark-good.service ${sysconfdir}/init.d/rauc-mark-good"
 
 PACKAGES =+ "${PN}-service"
-SYSTEMD_SERVICE:${PN}-service = "rauc.service"
+SYSTEMD_SERVICE:${PN}-service = "${@bb.utils.contains('PACKAGECONFIG', 'service', 'rauc.service', '', d)}"
 SYSTEMD_PACKAGES += "${PN}-service"
 RDEPENDS:${PN}-service += "dbus"
 

--- a/recipes-core/rauc/rauc.inc
+++ b/recipes-core/rauc/rauc.inc
@@ -11,6 +11,7 @@ EXTRA_OEMESON += "\
         -Dsystemdunitdir=${systemd_system_unitdir} \
         -Ddbuspolicydir=${datadir}/dbus-1/system.d \
         -Ddbussystemservicedir=${datadir}/dbus-1/system-services \
+        -Ddbusinterfacesdir=${datadir}/dbus-1/interfaces \
         "
 
 PACKAGECONFIG[nocreate]  = "-Dcreate=false,-Dcreate=true,"

--- a/recipes-core/rauc/rauc_1.10.1.bb
+++ b/recipes-core/rauc/rauc_1.10.1.bb
@@ -1,3 +1,3 @@
 require rauc.inc
 require rauc-target.inc
-require rauc-1.10.inc
+require rauc-1.10.1.inc


### PR DESCRIPTION
This is the 2023Q4.2 currency merge with upstream kirkstone branch
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2484331](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2484331)

Testing

* [x] bitbake packagefeed-ni-core
* [x] bitbake packagegroup-ni-desirable

@ni/rtos 